### PR TITLE
Fixed the bug of incorrect box drawing position.

### DIFF
--- a/app/src/main/java/com/danmo/guide/ui/components/OverlayView.kt
+++ b/app/src/main/java/com/danmo/guide/ui/components/OverlayView.kt
@@ -3,9 +3,11 @@ package com.danmo.guide.ui.components
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
 import org.tensorflow.lite.task.vision.detector.Detection
+import android.util.Log // 导入 Log 类
 
 class OverlayView(context: Context?, attrs: AttributeSet?) :
     View(context, attrs) {
@@ -13,6 +15,8 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
     private var textPaint: Paint? = null
     private var detections: List<Detection>? = null
     private var rotationDegrees = 0
+    private var width = 0
+    private var height = 0
 
     init {
         initPaint()
@@ -36,6 +40,12 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
         invalidate() // 请求重绘
     }
 
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        this.width = w
+        this.height = h
+    }
+
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
@@ -44,32 +54,87 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
         for (detection in detections!!) {
             val boundingBox = detection.boundingBox
 
-            // 根据旋转角度调整检测框的位置
-            if (rotationDegrees == 90) {
+            // 调整检测框位置
+            adjustBoundingBoxForRotation(boundingBox)
+
+            // 获取屏幕尺寸
+            val (deviceWidth, deviceHeight) = getDeviceDimensions()
+
+            // 计算并应用缩放比例
+            applyScalingToBoundingBox(boundingBox, deviceWidth, deviceHeight)
+
+            // 绘制检测框和标签
+            drawDetection(canvas, boundingBox, detection)
+        }
+    }
+
+    /**
+     * 根据旋转角度调整检测框的位置
+     */
+    private fun adjustBoundingBoxForRotation(boundingBox: RectF) {
+        when (rotationDegrees) {
+            90 -> {
                 val temp = boundingBox.left
                 boundingBox.left = boundingBox.top
-                boundingBox.top = width - boundingBox.right
+                boundingBox.top = height - boundingBox.right
                 boundingBox.right = boundingBox.bottom
-                boundingBox.bottom = width - temp
-            } else if (rotationDegrees == 180) {
+                boundingBox.bottom = height - temp
+            }
+            180 -> {
                 boundingBox.left = width - boundingBox.right
                 boundingBox.top = height - boundingBox.bottom
                 boundingBox.right = width - boundingBox.left
                 boundingBox.bottom = height - boundingBox.top
-            } else if (rotationDegrees == 270) {
-                val temp = boundingBox.left
-                boundingBox.left = height - boundingBox.bottom
-                boundingBox.top = boundingBox.right
-                boundingBox.right = height - boundingBox.top
-                boundingBox.bottom = boundingBox.right
             }
-
-            // 绘制检测框
-            canvas.drawRect(boundingBox, boxPaint!!)
-
-            // 绘制标签
-            val label = detection.categories[0].label
-            canvas.drawText(label, boundingBox.left, boundingBox.top - 10, textPaint!!)
+            270 -> {
+                val temp = boundingBox.left
+                boundingBox.left = width - boundingBox.bottom
+                boundingBox.top = boundingBox.right
+                boundingBox.right = width - boundingBox.top
+                boundingBox.bottom = temp
+            }
         }
+    }
+
+    /**
+     * 获取设备屏幕的宽度和高度
+     */
+    private fun getDeviceDimensions(): Pair<Float, Float> {
+        val displayMetrics = context.resources.displayMetrics
+        return Pair(displayMetrics.widthPixels.toFloat(), displayMetrics.heightPixels.toFloat())
+    }
+
+    /**
+     * 计算并应用缩放比例到检测框
+     */
+    private fun applyScalingToBoundingBox(boundingBox: RectF, deviceWidth: Float, deviceHeight: Float) {
+        val scaleX = deviceWidth / width
+        val scaleY = deviceHeight / height
+
+        boundingBox.left *= scaleX
+        boundingBox.top *= scaleY
+        boundingBox.right *= scaleX
+        boundingBox.bottom *= scaleY
+
+        // 输出调试信息
+        Log.d("OverlayView", "Device Width: $deviceWidth, Device Height: $deviceHeight")
+        Log.d("OverlayView", "View Width: $width, View Height: $height")
+        Log.d("OverlayView", "Scale X: $scaleX, Scale Y: $scaleY")
+        Log.d(
+            "OverlayView",
+            "Bounding Box: left=${boundingBox.left}, top=${boundingBox.top}, right=${boundingBox.right}, bottom=${boundingBox.bottom}"
+        )
+    }
+
+    /**
+     * 绘制检测框和标签
+     */
+    private fun drawDetection(canvas: Canvas, boundingBox: RectF, detection: Detection) {
+        // 绘制检测框
+        canvas.drawRect(boundingBox, boxPaint!!)
+
+        // 绘制标签
+        val label = detection.categories[0].label
+        canvas.drawText(label, boundingBox.left, boundingBox.top - 10, textPaint!!)
     }
 }

--- a/app/src/main/java/com/danmo/guide/ui/components/OverlayView.kt
+++ b/app/src/main/java/com/danmo/guide/ui/components/OverlayView.kt
@@ -5,80 +5,74 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
 import org.tensorflow.lite.task.vision.detector.Detection
-import android.util.Log // 导入 Log 类
 
-class OverlayView(context: Context?, attrs: AttributeSet?) :
-    View(context, attrs) {
+class OverlayView(context: Context?, attrs: AttributeSet?) : View(context, attrs) {
     private var boxPaint: Paint? = null
     private var textPaint: Paint? = null
     private var detections: List<Detection>? = null
     private var rotationDegrees = 0
     private var width = 0
     private var height = 0
+    private var modelInputWidth: Float = 0f
+    private var modelInputHeight: Float = 0f
 
     init {
         initPaint()
     }
 
     private fun initPaint() {
-        boxPaint = Paint()
-        boxPaint!!.color = -0xff0100 // 绿色
-        boxPaint!!.style = Paint.Style.STROKE
-        boxPaint!!.strokeWidth = 5f
-
-        textPaint = Paint()
-        textPaint!!.color = -0x1 // 白色
-        textPaint!!.textSize = 50f
-        textPaint!!.isAntiAlias = true
+        boxPaint = Paint().apply {
+            color = -0xff0100 // 绿色
+            style = Paint.Style.STROKE
+            strokeWidth = 5f
+        }
+        textPaint = Paint().apply {
+            color = -0x1 // 白色
+            textSize = 50f
+            isAntiAlias = true
+        }
     }
 
     fun updateDetections(detections: List<Detection>, rotationDegrees: Int) {
         this.detections = detections
         this.rotationDegrees = rotationDegrees
-        invalidate() // 请求重绘
+        invalidate()
+    }
+
+    fun setModelInputSize(width: Int, height: Int) {
+        modelInputWidth = width.toFloat()
+        modelInputHeight = height.toFloat()
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         this.width = w
         this.height = h
+        Log.d("OverlayView", "View Size: width=$w, height=$h")
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-
-        if (detections == null) return
-
-        for (detection in detections!!) {
+        detections?.forEach { detection ->
             val boundingBox = detection.boundingBox
-
-            // 调整检测框位置
             adjustBoundingBoxForRotation(boundingBox)
-
-            // 获取屏幕尺寸
-            val (deviceWidth, deviceHeight) = getDeviceDimensions()
-
-            // 计算并应用缩放比例
-            applyScalingToBoundingBox(boundingBox, deviceWidth, deviceHeight)
-
-            // 绘制检测框和标签
+            applyScalingToBoundingBox(boundingBox)
             drawDetection(canvas, boundingBox, detection)
         }
     }
 
-    /**
-     * 根据旋转角度调整检测框的位置
-     */
     private fun adjustBoundingBoxForRotation(boundingBox: RectF) {
+        Log.d("OverlayView", "Rotation: $rotationDegrees")
         when (rotationDegrees) {
             90 -> {
-                val temp = boundingBox.left
+                val tempLeft = boundingBox.left
                 boundingBox.left = boundingBox.top
                 boundingBox.top = height - boundingBox.right
                 boundingBox.right = boundingBox.bottom
-                boundingBox.bottom = height - temp
+                boundingBox.bottom = height - tempLeft
             }
             180 -> {
                 boundingBox.left = width - boundingBox.right
@@ -87,54 +81,37 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
                 boundingBox.bottom = height - boundingBox.top
             }
             270 -> {
-                val temp = boundingBox.left
+                val tempLeft = boundingBox.left
                 boundingBox.left = width - boundingBox.bottom
-                boundingBox.top = boundingBox.right
+                boundingBox.top = tempLeft
                 boundingBox.right = width - boundingBox.top
-                boundingBox.bottom = temp
+                boundingBox.bottom = boundingBox.right
             }
         }
     }
 
-    /**
-     * 获取设备屏幕的宽度和高度
-     */
-    private fun getDeviceDimensions(): Pair<Float, Float> {
-        val displayMetrics = context.resources.displayMetrics
-        return Pair(displayMetrics.widthPixels.toFloat(), displayMetrics.heightPixels.toFloat())
-    }
+    private fun applyScalingToBoundingBox(boundingBox: RectF) {
+        if (modelInputWidth == 0f || modelInputHeight == 0f) {
+            Log.e("OverlayView", "Model input size not set")
+            return
+        }
 
-    /**
-     * 计算并应用缩放比例到检测框
-     */
-    private fun applyScalingToBoundingBox(boundingBox: RectF, deviceWidth: Float, deviceHeight: Float) {
-        val scaleX = deviceWidth / width
-        val scaleY = deviceHeight / height
+        val scaleX = width / modelInputWidth
+        val scaleY = height / modelInputHeight
 
         boundingBox.left *= scaleX
         boundingBox.top *= scaleY
         boundingBox.right *= scaleX
         boundingBox.bottom *= scaleY
 
-        // 输出调试信息
-        Log.d("OverlayView", "Device Width: $deviceWidth, Device Height: $deviceHeight")
-        Log.d("OverlayView", "View Width: $width, View Height: $height")
-        Log.d("OverlayView", "Scale X: $scaleX, Scale Y: $scaleY")
-        Log.d(
-            "OverlayView",
-            "Bounding Box: left=${boundingBox.left}, top=${boundingBox.top}, right=${boundingBox.right}, bottom=${boundingBox.bottom}"
-        )
+        Log.d("OverlayView", "Scaling - Model: ${modelInputWidth}x${modelInputHeight}, View: ${width}x$height")
+        Log.d("OverlayView", "Bounding Box: $boundingBox")
     }
 
-    /**
-     * 绘制检测框和标签
-     */
-    private fun drawDetection(canvas: Canvas, boundingBox: RectF, detection: Detection) {
-        // 绘制检测框
-        canvas.drawRect(boundingBox, boxPaint!!)
-
-        // 绘制标签
-        val label = detection.categories[0].label
-        canvas.drawText(label, boundingBox.left, boundingBox.top - 10, textPaint!!)
+    private fun drawDetection(canvas: Canvas, rect: RectF, detection: Detection) {
+        canvas.drawRect(rect, boxPaint!!)
+        detection.categories.firstOrNull()?.label?.let {
+            canvas.drawText(it, rect.left, rect.top - 10, textPaint!!)
+        }
     }
 }

--- a/app/src/main/java/com/danmo/guide/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/danmo/guide/ui/main/MainActivity.kt
@@ -149,6 +149,8 @@ class MainActivity : ComponentActivity() {
                     val rotationDegrees = imageProxy.imageInfo.rotationDegrees
                     val results = objectDetectorHelper.detect(tensorImage, rotationDegrees)
 
+                    overlayView.setModelInputSize(tensorImage.width, tensorImage.height)
+                    Log.d("OverlayView", "View Size: tensorImage.width=${tensorImage.width}, tensorImage.height=${tensorImage.height}")
                     updateOverlayView(results, rotationDegrees)
                     updateStatusUI(results)
                     handleDetectionResults(results)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Sat Feb 15 04:26:47 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Fixed the bug of incorrect box drawing position
# Problem Description:
In the `OverlayView` class, when the device is rotated, there is an error in the calculation of the detection box position, causing the drawn box to be incorrectly positioned.
# Modifications:
1. Adjusted the bounding box position after rotation:
- In the `adjustBoundingBoxForRotation` method, corrected the logic for calculating bounding box coordinates at different rotation angles.
- Ensured that the bounding box coordinates are correctly transformed at rotations of `90`, `180`, and `270` degrees.
2. Optimized scaling processing:
- In the `applyScalingToBoundingBox` method, ensured accurate calculations of the ratio between model input size and view size.
- Added log records for cases where the model input size is not set, facilitating debugging.
3. Code Improvements:
- Formatted the relevant methods and added comments, improving the readability and maintainability of the code.